### PR TITLE
Added 'const' qualifier to every 'key' argument

### DIFF
--- a/aojls.c
+++ b/aojls.c
@@ -248,13 +248,13 @@ json_object* json_make_object(aojls_ctx_t* ctx) {
 	return o;
 }
 
-json_object* json_object_add(json_object* o, char* key, json_value_t* value) {
+json_object* json_object_add(json_object* o, const char* key, json_value_t* value) {
 	if (key == NULL)
 		return NULL;
 	return json_object_nadd(o, key, strlen(key), value);
 }
 
-json_object* json_object_nadd(json_object* o, char* key, size_t len, json_value_t* value) {
+json_object* json_object_nadd(json_object* o, const char* key, size_t len, json_value_t* value) {
 	if (o == NULL || value == NULL || key == NULL) {
 		if (o != NULL)
 			o->self.ctx->failed = true;
@@ -305,7 +305,7 @@ char* json_object_get_key(json_object* o, size_t i) {
 	return o->keys[i];
 }
 
-json_value_t* json_object_get_object_as_value(json_object* o, char* key) {
+json_value_t* json_object_get_object_as_value(json_object* o, const char* key) {
 	if (o == NULL || key == NULL) {
 		if (o != NULL)
 			o->self.ctx->failed = true;
@@ -319,7 +319,7 @@ json_value_t* json_object_get_object_as_value(json_object* o, char* key) {
 	return NULL; // not found
 }
 
-json_object* json_object_get_object(json_object* o, char* key) {
+json_object* json_object_get_object(json_object* o, const char* key) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	if (value == NULL) {
 		return NULL;
@@ -327,7 +327,7 @@ json_object* json_object_get_object(json_object* o, char* key) {
 	return json_as_object(value);
 }
 
-json_array* json_object_get_array(json_object* o, char* key) {
+json_array* json_object_get_array(json_object* o, const char* key) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	if (value == NULL) {
 		return NULL;
@@ -335,7 +335,7 @@ json_array* json_object_get_array(json_object* o, char* key) {
 	return json_as_array(value);
 }
 
-double json_object_get_double(json_object* o, char* key, bool* valid) {
+double json_object_get_double(json_object* o, const char* key, bool* valid) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	if (value == NULL) {
 		if (valid != NULL)
@@ -345,7 +345,7 @@ double json_object_get_double(json_object* o, char* key, bool* valid) {
 	return json_as_number(value, valid);
 }
 
-double json_object_get_double_default(json_object* o, char* key, double defval) {
+double json_object_get_double_default(json_object* o, const char* key, double defval) {
 	bool valid = false;
 	double result = json_object_get_double(o, key, &valid);
 	if (!valid)
@@ -353,7 +353,7 @@ double json_object_get_double_default(json_object* o, char* key, double defval) 
 	return result;
 }
 
-char* json_object_get_string(json_object* o, char* key) {
+char* json_object_get_string(json_object* o, const char* key) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	if (value == NULL) {
 		return NULL;
@@ -361,14 +361,14 @@ char* json_object_get_string(json_object* o, char* key) {
 	return json_as_string(value);
 }
 
-char* json_object_get_string_default(json_object* o, char* key, char* defval) {
+char* json_object_get_string_default(json_object* o, const char* key, char* defval) {
 	char* value = json_object_get_string(o, key);
 	if (value == NULL)
 		value = defval;
 	return value;
 }
 
-bool json_object_get_bool(json_object* o, char* key, bool* valid) {
+bool json_object_get_bool(json_object* o, const char* key, bool* valid) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	if (value == NULL) {
 		if (valid != NULL)
@@ -378,7 +378,7 @@ bool json_object_get_bool(json_object* o, char* key, bool* valid) {
 	return json_as_bool(value, valid);
 }
 
-bool json_object_get_bool_default(json_object* o, char* key, bool defval) {
+bool json_object_get_bool_default(json_object* o, const char* key, bool defval) {
 	bool valid = false;
 	bool result = json_object_get_bool(o, key, &valid);
 	if (!valid)
@@ -386,7 +386,7 @@ bool json_object_get_bool_default(json_object* o, char* key, bool defval) {
 	return result;
 }
 
-bool json_object_is_null(json_object* o, char* key) {
+bool json_object_is_null(json_object* o, const char* key) {
 	json_value_t* value = json_object_get_object_as_value(o, key);
 	return json_is_null(value);
 }

--- a/aojls.h
+++ b/aojls.h
@@ -228,7 +228,7 @@ json_object* json_make_object(aojls_ctx_t* ctx);
  * @warning Key must be null terminated and will be copied and stored in the context bound to the
  * JSON object!
  */
-json_object* json_object_add(json_object* o, char* key, json_value_t* value);
+json_object* json_object_add(json_object* o, const char* key, json_value_t* value);
 /**
  * @brief Adds key-value pair to this JSON object
  *
@@ -240,7 +240,7 @@ json_object* json_object_add(json_object* o, char* key, json_value_t* value);
  * @warning Key may not be null terminated and will be copied and stored in the context bound to the
  * JSON object!
  */
-json_object* json_object_nadd(json_object* o, char* key, size_t len, json_value_t* value);
+json_object* json_object_nadd(json_object* o, const char* key, size_t len, json_value_t* value);
 
 /**
  * @return number of keys in this JSON object
@@ -266,21 +266,21 @@ char* json_object_get_key(json_object* o, size_t i);
  * @param key
  * @return JSON value bound to that key or NULL in case of an error or no such key in this JSON object
  */
-json_value_t* json_object_get_object_as_value(json_object* o, char* key);
+json_value_t* json_object_get_object_as_value(json_object* o, const char* key);
 /**
  * @brief Returns JSON object bound to this key.
  * @return JSON object bound to that key or NULL in case of an error, if there is no such key or if key points to
  * other than JSON object JSON value.
  * @see json_object_get_key
  */
-json_object* json_object_get_object(json_object* o, char* key);
+json_object* json_object_get_object(json_object* o, const char* key);
 /**
  * @brief Returns JSON array bound to this key.
  * @return JSON array bound to that key or NULL in case of an error, if there is no such key or if key points to
  * other than JSON array JSON value.
  * @see json_object_get_key
  */
-json_array* json_object_get_array(json_object* o, char* key);
+json_array* json_object_get_array(json_object* o, const char* key);
 /**
  * @brief Returns double bound to this key.
  * @param o JSON object
@@ -290,7 +290,7 @@ json_array* json_object_get_array(json_object* o, char* key);
  * other than JSON number JSON value.
  * @see json_object_get_key
  */
-double json_object_get_double(json_object* o, char* key, bool* valid);
+double json_object_get_double(json_object* o, const char* key, bool* valid);
 /**
  * @brief Returns double bound to this key or default value.
  * @param o JSON object
@@ -300,7 +300,7 @@ double json_object_get_double(json_object* o, char* key, bool* valid);
  * other than JSON number JSON value.
  * @see json_object_get_key
  */
-double json_object_get_double_default(json_object* o, char* key, double defval);
+double json_object_get_double_default(json_object* o, const char* key, double defval);
 /**
  * @brief Returns string bound to this key.
  * @param o JSON object
@@ -309,7 +309,7 @@ double json_object_get_double_default(json_object* o, char* key, double defval);
  * other than JSON string JSON value.
  * @see json_object_get_key
  */
-char* json_object_get_string(json_object* o, char* key);
+char* json_object_get_string(json_object* o, const char* key);
 /**
  * @brief Returns string bound to this key or default value.
  * @param o JSON object
@@ -319,7 +319,7 @@ char* json_object_get_string(json_object* o, char* key);
  * other than JSON string JSON value.
  * @see json_object_get_key
  */
-char* json_object_get_string_default(json_object* o, char* key, char* defval);
+char* json_object_get_string_default(json_object* o, const char* key, char* defval);
 /**
  * @brief Returns boolean bound to this key.
  * @param o JSON object
@@ -329,8 +329,8 @@ char* json_object_get_string_default(json_object* o, char* key, char* defval);
  * other than JSON boolean JSON value.
  * @see json_object_get_key
  */
-bool json_object_get_bool(json_object* o, char* key, bool* valid);
-bool json_object_get_bool_default(json_object* o, char* key, bool defval);
+bool json_object_get_bool(json_object* o, const char* key, bool* valid);
+bool json_object_get_bool_default(json_object* o, const char* key, bool defval);
 /**
  * @brief Returns if null is bound for that key
  * @param o JSON object
@@ -338,7 +338,7 @@ bool json_object_get_bool_default(json_object* o, char* key, bool defval);
  * @return true if JSON null is bound to that key
  * @see json_object_get_key
  */
-bool json_object_is_null(json_object* o, char* key);
+bool json_object_is_null(json_object* o, const char* key);
 
 /* Array */
 


### PR DESCRIPTION
Those keys are not changed by methods using them and so there is no need to declare is as non-const.

Doing this silences warnings like:

```
sc-controller/src/config/config.c:249:48: warning: passing argument 2 of ‘json_object_get_object_as_value’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
    return json_object_get_object_as_value(obj, json_path);
```